### PR TITLE
Fix "Hash Functions Domain Separation"

### DIFF
--- a/pkg/zk/sch/sch.go
+++ b/pkg/zk/sch/sch.go
@@ -57,12 +57,12 @@ func NewRandomness(rand io.Reader, group curve.Curve, gen curve.Point) *Randomne
 }
 
 func challenge(hash *hash.Hash, group curve.Curve, commitment *Commitment, public, gen curve.Point) (e curve.Scalar, err error) {
-	err = hash.WriteAny(commitment.C, public, gen)
+	err = hash.WriteAny("a_i0", commitment.C, public, gen)
 	e = sample.Scalar(hash.Digest(), group)
 	return
 }
 
-// Prove creates a Response = Randomness + H(..., Commitment, public)•secret (mod p).
+// Prove creates a Response = Randomness + H(..., domain('a_i0'), Commitment, public)•secret (mod p).
 func (r *Randomness) Prove(hash *hash.Hash, public curve.Point, secret curve.Scalar, gen curve.Point) *Response {
 	if gen == nil {
 		gen = public.Curve().NewBasePoint()

--- a/protocols/frost/keygen/round1.go
+++ b/protocols/frost/keygen/round1.go
@@ -15,7 +15,8 @@ import (
 )
 
 // This round corresponds with the steps 1-4 of Round 1, Figure 1 in the Frost paper:
-//   https://eprint.iacr.org/2020/852.pdf
+//
+//	https://eprint.iacr.org/2020/852.pdf
 type round1 struct {
 	*round.Helper
 	// taproot indicates whether or not to make taproot compatible keys.
@@ -115,7 +116,7 @@ func (r *round1) Finalize(out chan<- *round.Message) (round.Session, error) {
 	if err != nil {
 		return r, fmt.Errorf("failed to sample ChainKey")
 	}
-	commitment, decommitment, err := r.HashForID(r.SelfID()).Commit(c_i)
+	commitment, decommitment, err := r.HashForID(r.SelfID()).Commit("c_i", c_i)
 	if err != nil {
 		return r, fmt.Errorf("failed to commit to chain key")
 	}

--- a/protocols/frost/sign/round2.go
+++ b/protocols/frost/sign/round2.go
@@ -96,6 +96,7 @@ func (r *round2) Finalize(out chan<- *round.Message) (round.Session, error) {
 	// This calculates H(m, B), allowing us to avoid re-hashing this data for
 	// each extra party l.
 	rhoPreHash := hash.New()
+	_ = rhoPreHash.WriteAny("rho_i")
 	_ = rhoPreHash.WriteAny(r.M)
 	for _, l := range r.PartyIDs() {
 		_ = rhoPreHash.WriteAny(r.D[l], r.E[l])
@@ -136,7 +137,7 @@ func (r *round2) Finalize(out chan<- *round.Message) (round.Session, error) {
 		c = r.Group().NewScalar().SetNat(new(saferith.Nat).SetBytes(cHash))
 	} else {
 		cHash := hash.New()
-		_ = cHash.WriteAny(R, r.Y, r.M)
+		_ = cHash.WriteAny("c_challange", R, r.Y, r.M)
 		c = sample.Scalar(cHash.Digest(), r.Group())
 	}
 


### PR DESCRIPTION
I'm not sure if these domains are standardized so I used strings related to what hash is used for