### PR TITLE
Fix "Keying material not properly de-allocated"

### DIFF
--- a/protocols/frost/keygen/round3.go
+++ b/protocols/frost/keygen/round3.go
@@ -110,6 +110,7 @@ func (r *round3) Finalize(chan<- *round.Message) (round.Session, error) {
 	for l, f_li := range r.shareFrom {
 		r.privateShare.Add(f_li)
 		// TODO: Maybe actually clear this in a better way
+		r.shareFrom[l].UnmarshalBinary(make([]byte, 32))
 		delete(r.shareFrom, l)
 	}
 


### PR DESCRIPTION
I don't think there's a way to wipe scalar bytes in secp package using memguard, so I sort of zeroed them before map delete